### PR TITLE
Simplify a condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1197,7 +1197,7 @@ moves_loop: // When in check, search starts here
           // deeper than the first move (this may lead to hidden double extensions).
           int deeper =   r >= -1                   ? 0
                        : moveCount <= 4            ? 2
-                       : PvNode && depth > 4       ? 1
+                       : PvNode                    ? 1
                        : cutNode && moveCount <= 8 ? 1
                        :                             0;
 


### PR DESCRIPTION
Principal variation depth late move reduction extension simplification.

stc:
https://tests.stockfishchess.org/tests/view/6285a1d19d18a78568e7fa24
LLR: 2.94 (-2.94,2.94) <-2.25,0.25>
Total: 428536 W: 113433 L: 113851 D: 201252
Ptnml(0-2): 1671, 48606, 114090, 48272, 1629

ltc:
https://tests.stockfishchess.org/tests/view/62871d20375cdc5de8cf5db3
LLR: 2.95 (-2.94,2.94) <-2.25,0.25>
Total: 56792 W: 15123 L: 15011 D: 26658
Ptnml(0-2): 42, 5681, 16825, 5819, 29

closes https://github.com/official-stockfish/Stockfish/pull/4028

bench: 6501437